### PR TITLE
Change snap-plugin-collector-docker url to adrianliaw's repository

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -13,7 +13,7 @@ echo
 
 curl -sfL "http://snap.ci.snap-telemetry.io/plugins/snap-plugin-collector-meminfo/latest/linux/x86_64/snap-plugin-collector-meminfo" -o snap-plugin-collector-meminfo
 curl -sfL "https://github.com/intelsdi-x/snap-plugin-publisher-influxdb/releases/download/16/snap-plugin-publisher-influxdb_linux_x86_64" -o snap-plugin-publisher-influxdb
-curl -sfL "https://github.com/intelsdi-x/snap-plugin-collector-docker/releases/download/5/snap-plugin-collector-docker_linux_x86_64" -o snap-plugin-collector-docker
+curl -sfL "https://github.com/adrianliaw/snap-plugin-collector-docker/releases/download/6-name/snap-plugin-collector-docker_linux_x86_64" -o snap-plugin-collector-docker
 curl -sfL "https://github.com/intelsdi-x/snap-plugin-collector-disk/releases/download/4/snap-plugin-collector-disk_linux_x86_64" -o snap-plugin-collector-disk
 curl -sfL "https://github.com/intelsdi-x/snap-plugin-collector-psutil/releases/download/8/snap-plugin-collector-psutil_linux_x86_64" -o snap-plugin-collector-psutil
 


### PR DESCRIPTION
adrianliaw/snap-plugin-collector-docker added an additional functionality of collecting container names